### PR TITLE
Modified README to fix errors when following console instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ for Chase and save the file.
 Now fire up the test client and start a job:
 
     ssu$ script/console
+    >> chase = File.read('./credentials/chase')
     >> job = Job.create chase
 
 Your first terminal window and the blank browser should now be doing
@@ -167,6 +168,7 @@ site. Once you've added something and created a matching credential file, go
 ahead and try it out:
 
     ssu$ script/console
+    >> ally = File.read('./credentials/ally')
     >> job.start ally
 
 There are lots of examples in the `fi-scripts` directory for you to reference


### PR DESCRIPTION
When following the instructions in creating a "chase" job in the console. The "chase" variable is undefined so I added a line that fixes that for anyone that also wants to try it out.
